### PR TITLE
Fixed bug and memory issue in FilteredAnitaEvent that returned wrong waveform when using ring,phi,pol

### DIFF
--- a/src/FilteredAnitaEvent.cc
+++ b/src/FilteredAnitaEvent.cc
@@ -482,9 +482,9 @@ const AnalysisWaveform *FilteredAnitaEvent::getRawGraph(UInt_t phi,
 							AnitaRing::AnitaRing_t ring,
 							AnitaPol::AnitaPol_t pol) const {
 
-  Int_t chanIndex = AnitaGeomTool::getChanIndexFromRingPhiPol(ring,phi,pol);
-  return rawGraphs[chanIndex];
-  
+    // this works for A4 and should work for A3.
+    const Int_t ant = 16*ring + phi;
+    return rawGraphsByAntPol[pol][ant];
 }
 
 
@@ -493,8 +493,7 @@ const AnalysisWaveform *FilteredAnitaEvent::getRawGraph(UInt_t phi,
 const AnalysisWaveform * FilteredAnitaEvent::getFilteredGraph(UInt_t phi, 
 							      AnitaRing::AnitaRing_t ring, 
 							      AnitaPol::AnitaPol_t pol) const {
-
-  Int_t chanIndex = AnitaGeomTool::getChanIndexFromRingPhiPol(ring,phi,pol);
-  return filteredGraphs[chanIndex];
-  
+    // this works for A4 and should work for A3.
+    const Int_t ant = 16*ring + phi;
+    return filteredGraphsByAntPol[pol][ant];
 }


### PR DESCRIPTION
The current `getFilteredGraph` and `getRawGraph` methods were incorrect when using the `ring,phi,pol` method. The mapping used to store the waveforms into `rawGraphs[]` and `filteredGraphs[]` was incorrect - there was also an OOB memory issue where calls to `getRawGraph` could return a filtered graph instead. This has been fixed by manually indexing into the appropriate array of waveform pointers. 